### PR TITLE
Test PR using workflow_run

### DIFF
--- a/.github/workflows/run_benches.yml
+++ b/.github/workflows/run_benches.yml
@@ -1,3 +1,4 @@
+# Example PR
 on:
   pull_request:
     types: [labeled, opened, reopened, synchronize]


### PR DESCRIPTION
This new test PR uses `workflow_run` which needs to exist on the repository default branch.